### PR TITLE
Removal of debug message

### DIFF
--- a/src/LDAP.cc
+++ b/src/LDAP.cc
@@ -719,7 +719,6 @@ public:
         if (!srv_controls) {
           //MakeCallback(c->handle_,symbol_search,3,args);
 		  args[0] = symbol_search;
-		  fprintf(stderr,"emit search event\n");
 	      emit->Call(c->handle_, 4, args); // this is equivilent to: this.emit("search",msgid,int_res,ldap_res);
 	      if (tc.HasCaught()) {
 	        FatalException(tc);


### PR DESCRIPTION
Since 83923349fa0219b5831cdd44b686e7ba76955155 an obviously unnecessary debug message (`emit search event`) is written to stderr on every search, fixing that.
