### PR TITLE
Fix linker flag in binding.gyp for mac build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,11 @@
             "libraries": [
               "-lldap"
             ]
+          },
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-L/usr/local/lib'
+            ]
           }
          }
         ]


### PR DESCRIPTION
I'm using node.js v0.10.15 on Mac OS X 10.8.3. When I ran tests/run_test.sh, I got this error:

```
BINARY                           [OK]
SCHEMA                           [OK]
dyld: lazy symbol binding failed: Symbol not found: _ldap_sync_initialize
  Referenced from: /Users/top/wavify/node-LDAP/build/Release/LDAP.node
  Expected in: dynamic lookup

dyld: Symbol not found: _ldap_sync_initialize
  Referenced from: /Users/top/wavify/node-LDAP/build/Release/LDAP.node
  Expected in: dynamic lookup

./run_tests.sh: line 17: 57972 Trace/BPT trap: 5       node alltests.js $SLAPD_PID
```

It seems that the binary looks for dynamic library in /usr/lib, which contains the older ldap library came with my OS X installation, instead of /usr/local/lib as specified in binding.gyp. Running "npm --verbose install" confirms that node-gyp ignores ldflags in binding.gyp entirely.

I've found a similar issue as well as the solution here: https://gist.github.com/TooTallNate/1590684/#comment-74821.

This pull request fixes the problem by specifying ldflags in extra "xcode_settings" block.
