### PR TITLE
Allow passing an empty string ( "" ) as base to support reading rootDSE

### DIFF
--- a/LDAP.js
+++ b/LDAP.js
@@ -258,7 +258,7 @@ var LDAP = function(opts) {
         if (!s_opts) {
             throw new Error("Opts required");
         }
-        if (!s_opts.base) {
+        if (typeof s_opts.base != 'string') {
             throw new Error("Base required");
         }
 


### PR DESCRIPTION
Active Directory makes extensive use of rootDSE entry to provide
information about the environment to clients. Empty string evaluates to
FALSE so reading rootDSE is not possible without this patch.
