### PR TITLE
package.json: update node version to match README.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./LDAP.js",
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.8.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
The node dependency version in the package.json file has fallen out
of sync with the required version specified in the README.md. Update
package.json to match the README.md.
