### PR TITLE
Release version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-node-LDAP 1.1.6
+node-LDAP 1.2.0
 ===============
 
 OpenLDAP client bindings for Node.js. Requires libraries from
@@ -37,7 +37,7 @@ Install
 You must ensure you have the latest OpenLDAP client libraries
 installed from http://www.openldap.org
 
-To install the 1.1.6 release from npm:
+To install the latest release from npm:
 
     npm install LDAP
 
@@ -54,9 +54,12 @@ Creating an instance:
 
 ```js
 var LDAP = require('LDAP');
-var ldap = new LDAP({ uri: 'ldap://my.ldap.server',
-                      version: 3,
-                      connecttimeout: 1});
+var ldap = new LDAP({
+    uri: 'ldap://my.ldap.server',
+    version: 3,
+    connecttimeout: 1,
+    reconnect: true
+});
 ```
 
 ldap.open()
@@ -76,6 +79,9 @@ ldap.open(function(err) {
 
 });
 ```
+
+You can disable the automatic reconnect by setting the `reconnect`
+option to false.
 
 ldap.simplebind()
 -----------------
@@ -161,6 +167,17 @@ search_options = {
     attrs: '',
     pagesize: n,
     cookie: cookie
+}
+```
+
+As of version 1.2.0 you can also read the rootDSE entry of an ldap server.
+To do so, simply issue a read request with base set to an empty string:
+
+```js
+search_options = {
+  base: '',
+  scope: Connection.BASE,  // 0
+  // ... other options as necessary
 }
 ```
 
@@ -255,6 +272,23 @@ Example:
 
 ```js
 ldap.rename('cn=name,dc=example,dc=com', 'cn=newname')
+```
+
+ldap.remove()
+-------------
+
+    ldap.remove(dn, function(err))
+
+Deletes an entry.
+
+Example:
+
+```js
+ldap.remove('cn=name,dc=example,dc=com', function(err) {
+  if (err) {
+    // Could not delete entry
+  }
+});
 ```
 
 Schema

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jeremy Childs <jeremyc@ssimicro.com>",
   "name": "LDAP",
   "description": "LDAP Binding for node.js",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "homepage": "https://github.com/jeremycx/node-LDAP",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's been quite some time since 1.1.6 was published on NPM and this module evolved substantially since then, so I thought we could release a new version on NPM.

I have raised the version to 1.2.0 due to numerous bux fixes and new features. Changelog follows.
#### Fixes:
- a9e46d3 Fixed an issue with converting some binary attributes
- 92de842 Fixed compilation issue on Mac systems
- 7f82de0 Fixed possible memory leak when bind() request fails
- 3319aee Fixed issue with exceeding max call stack size when ldap server is stopped
- 6cfd358 Fixed issue with the reconnect() method opening more connections to server than necessary
- Various minor fixes and improvements
#### New features:
- 5c04505 New remove() method for deleting an entry
- 368b5de New option to disable automatic reconnect on lost connection
- a0904aa Errors are now returned via LDAPError instance containing both error message and error code
- 3db276b The search() method now accepts empty strings ("") as search base to allow reading rootDSE entries

Let me know if there's anything else I can do to have this merged and published on NPM.
Thanks in advance!
