### PR TITLE
Add StartTLS connection support

### DIFF
--- a/LDAP.js
+++ b/LDAP.js
@@ -49,6 +49,7 @@ var LDAP = function(opts) {
         throw new LDAPError('You must provide a URI');
     }
 
+    opts.starttls = opts.starttls || false;
     opts.timeout = opts.timeout || 5000;
     opts.backoff = 1; //sec
     opts.backoffmax = opts.backoffmax || 32; //sec
@@ -120,7 +121,7 @@ var LDAP = function(opts) {
         stats.opens++;
         binding = new LDAPConnection();
         setcallbacks();
-        binding.open(opts.uri || 'ldap://localhost', (opts.version || 3), (opts.connecttimeout || -1));
+        binding.open(opts.uri || 'ldap://localhost', (opts.starttls || false), (opts.version || 3), (opts.connecttimeout || -1));
         return bind(fn); // do an anon bind to get it all ready.
     }
 

--- a/src/LDAP.cc
+++ b/src/LDAP.cc
@@ -226,8 +226,9 @@ public:
     GETOBJ(c);
 
     ARG_STR(uri, 0);
-    ARG_INT(ver, 1);
-    ARG_INT(timeout, 2);
+    ARG_BOOL(starttls, 1);
+    ARG_INT(ver, 2);
+    ARG_INT(timeout, 3);
 
     LJSDEB("OPEN1 %s:%u %p %p\n", c, c->ld);
 
@@ -253,6 +254,10 @@ public:
 
     ldap_set_option(c->ld, LDAP_OPT_RESTART, LDAP_OPT_ON);
     ldap_set_option(c->ld, LDAP_OPT_PROTOCOL_VERSION, &ver);
+
+    if (starttls == 1) {      
+      ldap_start_tls_s(c->ld, NULL, NULL);
+    }
 
     LJSDEB("OPEN: %s:%u %p %p\n", c, c->ld);
 


### PR DESCRIPTION
``` js
/*
 * LDAP connection with StartTLS
 */
var ldap = require("LDAP");

var l = new ldap({
    uri: "ldap://ldap.my.domain",
    starttls: true,
    binddn: "uid=proxy,dc=my,dc=domain",
    password: "mypassword",
});

l.open(function(err) {
    if (err)
        console.log("l.open() => error=" + err);

    l.close();
});
```
