### PR TITLE
Define LDAPConnection in local namespace

### DIFF
--- a/LDAP.js
+++ b/LDAP.js
@@ -1,6 +1,8 @@
 var events = require('events')
     , util = require('util');
 
+var LDAPConnection;
+
 try {
     LDAPConnection = require('./build/default/LDAP').LDAPConnection;
 } catch(e) {


### PR DESCRIPTION
Defining the `LDAPConnection` in global namespace is not necessary.
