### PR TITLE
add objectGUID to be interpreted as binary attribute

### DIFF
--- a/src/LDAP.cc
+++ b/src/LDAP.cc
@@ -716,6 +716,7 @@ public:
         !strcmp(attrname, "thumbnailLogo") ||
         !strcmp(attrname, "supportedAlgorithms") ||
         !strcmp(attrname, "protocolInformation") ||
+        !strcmp(attrname, "objectGUID") ||
         strstr(attrname, ";binary")) {
       return 1;
     }


### PR DESCRIPTION
While this fixes my immediate issue, long term solution should probably be more flexible. Quick glance at RFC indicates it should be possible to somehow discover this information from schema, but I have no idea how hard this would be. Or as an alternative, create javascript API to allow developers to specify which attributes they wants to receive as Buffers - this should be reasonably easy and developer friendly.
