### PR TITLE
Remove unistd.h header (no functions used from it)

### DIFF
--- a/src/LDAP.cc
+++ b/src/LDAP.cc
@@ -5,7 +5,6 @@
 #include <node.h>
 #include <node_buffer.h>
 #include <node_object_wrap.h>
-#include <unistd.h>
 #include <errno.h>
 
 #include <ldap.h>


### PR DESCRIPTION
This seems to be no longer used - at least the build succeeds without any complaints about missing function definitions etc. Also addresses Win32 compatibility as this is a POSIX header not natively available on that platform.

Closes #57.
