### PR TITLE
findandbind: pass found entry to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,10 +193,14 @@ LDAP.prototype.findandbind = function(opt, fn) {
         if (this.auth_connection === undefined) {
             this.auth_connection = new LDAP(this.options, function newAuthConnection(err) {
                 if (err) return fn(err);
-                return this.authbind(data[0].dn, opt.password, fn);
+                return this.authbind(data[0].dn, opt.password, function authbindResult(err) {
+                    fn(err, data[0]);
+                });
             }.bind(this));
         } else {
-            this.authbind(data[0].dn, opt.password, fn);
+            this.authbind(data[0].dn, opt.password, function authbindResult(err) {
+                fn(err, data[0]);
+            });
         }
         return undefined;
     }.bind(this));

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,7 @@ describe('LDAP', function() {
             password: 'foobarbaz'
         }, function(err, data) {
             assert.ifError(err);
+            assert.equal(data.cn, 'Charlie');
             done();
         });
     });
@@ -100,6 +101,7 @@ describe('LDAP', function() {
             password: 'foobarbaz'
         }, function(err, data) {
             assert.ifError(err);
+            assert.equal(data.cn, 'Charlie');
             done();
         });
     });


### PR DESCRIPTION
Prior versions of `findandbind()` passed `(err, data)` to the callback.
This functionality was broken, I believe inadvertently, in commit
a4b9ce6e8eda61d1c86faf20995464d538b20f6c It's still documented in
the README and the callbacks in the unit tests still accept
`(err, data)`. Since it was broken in a minor version bump (3.0->3.1),
it will break existing code that relies on `data` being passed back
and uses the caret operator to specify dependency versions.

Restore that functionality, by passing the found entry
to the callback supplied to `findandbind()`.