### PR TITLE
Add SASL bind support.

### DIFF
--- a/LDAPCnx.cc
+++ b/LDAPCnx.cc
@@ -200,7 +200,7 @@ void LDAPCnx::Event(uv_poll_t* handle, int status, int events) {
             int msgid = ldap_msgid(message);
 
             if(err == LDAP_SASL_BIND_IN_PROGRESS) {
-              err = ld->SASLBindNext(message);
+              err = ld->SASLBindNext(&message);
               if(err != LDAP_SUCCESS) {
                 errparam = Nan::Error(ldap_err2string(err));
               }

--- a/LDAPCnx.h
+++ b/LDAPCnx.h
@@ -25,6 +25,7 @@ class LDAPCnx : public Nan::ObjectWrap {
   static void Search      (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Delete      (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Bind        (const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void SASLBind    (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Add         (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Modify      (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Rename      (const Nan::FunctionCallbackInfo<v8::Value>& info);
@@ -37,6 +38,9 @@ class LDAPCnx : public Nan::ObjectWrap {
   static void InstallTLS  (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void CheckTLS    (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static int isBinary     (char * attrname);
+
+  int SASLBindNext(LDAPMessage* result);
+  const char* sasl_mechanism;
 
   ldap_conncb * ldap_callback;
   uv_poll_t * handle;

--- a/LDAPCnx.h
+++ b/LDAPCnx.h
@@ -39,7 +39,7 @@ class LDAPCnx : public Nan::ObjectWrap {
   static void CheckTLS    (const Nan::FunctionCallbackInfo<v8::Value>& info);
   static int isBinary     (char * attrname);
 
-  int SASLBindNext(LDAPMessage* result);
+  int SASLBindNext(LDAPMessage** result);
   const char* sasl_mechanism;
 
   ldap_conncb * ldap_callback;

--- a/LDAPSASL.cc
+++ b/LDAPSASL.cc
@@ -1,0 +1,63 @@
+#include <sasl/sasl.h>
+#include "LDAPCnx.h"
+#include "SASLDefaults.h"
+
+using namespace v8;
+
+void LDAPCnx::SASLBind(const Nan::FunctionCallbackInfo<Value>& info) {
+
+  LDAPCnx* ld = ObjectWrap::Unwrap<LDAPCnx>(info.Holder());
+
+  if (ld->ld == NULL) {
+    Nan::ThrowError("LDAP connection has not been established");
+  }
+
+  v8::String::Utf8Value mechanism(SASLDefaults::Get(info[0]));
+  SASLDefaults defaults(info[1], info[2], info[3], info[4]);
+  v8::String::Utf8Value sec_props(SASLDefaults::Get(info[5]));
+
+  if(*sec_props) {
+    int res = ldap_set_option(ld->ld, LDAP_OPT_X_SASL_SECPROPS, *sec_props);
+    if(res != LDAP_SUCCESS) {
+      Nan::ThrowError(ldap_err2string(res));
+    }
+  }
+
+  int msgid;
+  LDAPControl** sctrlsp = NULL;
+  LDAPMessage* message = NULL;
+  ld->sasl_mechanism = NULL;
+
+  int res = ldap_sasl_interactive_bind(ld->ld, NULL, *mechanism,
+    sctrlsp, NULL, LDAP_SASL_QUIET, &SASLDefaults::Callback, &defaults, 
+    message, &ld->sasl_mechanism, &msgid);
+  if(res != LDAP_SASL_BIND_IN_PROGRESS && res != LDAP_SUCCESS) {
+    Nan::ThrowError(ldap_err2string(res));
+  }
+
+  info.GetReturnValue().Set(msgid);
+}
+
+int LDAPCnx::SASLBindNext(LDAPMessage* message) {
+  LDAPControl** sctrlsp = NULL;
+  int res; 
+  int msgid;
+  do {
+    res = ldap_sasl_interactive_bind(ld, NULL, NULL,
+      sctrlsp, NULL, LDAP_SASL_QUIET, NULL, NULL,
+      message, &sasl_mechanism, &msgid);
+
+    if(res != LDAP_SASL_BIND_IN_PROGRESS) {
+      break;
+    }
+
+    if(ldap_result(ld, msgid, LDAP_MSG_ALL, NULL, &message) != LDAP_SUCCESS) { 
+      ldap_get_option(ld, LDAP_OPT_RESULT_CODE, &res);
+      break;
+    }
+
+  } while(res == LDAP_SASL_BIND_IN_PROGRESS);
+
+  return res;
+}
+

--- a/LDAPXSASL.cc
+++ b/LDAPXSASL.cc
@@ -4,6 +4,6 @@ void LDAPCnx::SASLBind(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   Nan::ThrowError("LDAP module was not built with SASL support");
 }
 
-int LDAPCnx::SASLBindNext(LDAPMessage* result) {
+int LDAPCnx::SASLBindNext(LDAPMessage** result) {
   return -1;
 }

--- a/LDAPXSASL.cc
+++ b/LDAPXSASL.cc
@@ -1,0 +1,9 @@
+#include "LDAPCnx.h"
+
+void LDAPCnx::SASLBind(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::ThrowError("LDAP module was not built with SASL support");
+}
+
+int LDAPCnx::SASLBindNext(LDAPMessage* result) {
+  return -1;
+}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ To install the latest release from npm:
 
 You will also require the LDAP Development Libraries (on Ubuntu, `sudo apt-get install libldap2-dev`)
 
+For SASL authentication support the Cyrus SASL libraries need to be installed
+and OpenLDAP needs to be built with SASL support.
+
 Reconnection
 ==========
 If the connection fails during operation, the client library will handle the reconnection, calling the function specified in the connect option. This callback is a good place to put bind()s and other things you want to always be in place.
@@ -120,6 +123,32 @@ bind_options = {
 }
 ```
 Aliased to `ldap.simplebind()` for backward compatibility.
+
+
+ldap.saslbind()
+===
+Upgrade the existing anonymous bind to an authenticated bind using SASL.
+
+    ldap.saslbind([bind_options,] function(err));
+
+Options are: 
+
+* mechanism - If not provided SASL library will select based on the best 
+  mechanism available on the server.
+* user - Authentication user if required by mechanism
+* password - Authentication user's password if required by mechanism
+* realm - Non-default SASL realm if required by mechanism
+* proxyuser - Authorization (proxy) user if supported by mechanism
+* securityproperties - Optional SASL security properties
+
+All parameters are optional.  For example a GSSAPI (Kerberos) bind can be
+initiated as follows:
+
+```
+	ldap.saslbind(function(err) { if(err) throw err; });
+```
+
+For details refer to the [SASL documentation](http://cyrusimap.org/docs/cyrus-sasl).
 
 
 ldap.search()

--- a/SASLDefaults.cc
+++ b/SASLDefaults.cc
@@ -1,0 +1,36 @@
+#include <sasl/sasl.h>
+#include "SASLDefaults.h"
+
+void SASLDefaults::Set(unsigned flags, sasl_interact_t *interact) {
+  const char *dflt = interact->defresult;
+
+  switch (interact->id) {
+  case SASL_CB_AUTHNAME:
+    dflt = *user;
+    break;
+  case SASL_CB_PASS:
+    dflt = *password;
+    break;
+  case SASL_CB_GETREALM:
+    dflt = *realm;
+    break;
+  case SASL_CB_USER:
+    dflt = *proxy_user;
+    break;
+  }
+
+  interact->result = (dflt && *dflt) ? dflt : "";
+  interact->len = strlen((const char*)interact->result);
+}
+
+int SASLDefaults::Callback(LDAP *ld, unsigned flags, void *defaults, void *in) {
+  SASLDefaults* self = (SASLDefaults*)defaults;
+  sasl_interact_t *interact = (sasl_interact_t*)in;
+  while(interact->id != SASL_CB_LIST_END) {
+    self->Set(flags, interact);
+    ++interact;
+  }
+
+  return LDAP_SUCCESS;
+}
+

--- a/SASLDefaults.h
+++ b/SASLDefaults.h
@@ -1,0 +1,32 @@
+#include <nan.h>
+#include <ldap.h>
+
+struct SASLDefaults {
+  SASLDefaults(
+    const v8::Local<v8::Value>& usr,
+    const v8::Local<v8::Value>& pw,
+    const v8::Local<v8::Value>& rlm,
+    const v8::Local<v8::Value>& proxy
+  ) : 
+    user(Get(usr)), 
+    password(Get(pw)),
+    realm(Get(rlm)), 
+    proxy_user(Get(proxy))
+  {}
+
+  // Returns a C NULL value if not a string 
+  static inline v8::Local<v8::Value> Get(const v8::Local<v8::Value>& v) {
+    return v->IsString() ? v : v8::Local<v8::Value>();
+  }
+
+  static int Callback(LDAP *ld, unsigned flags, void *defaults, void *in);
+
+  v8::String::Utf8Value user;
+  v8::String::Utf8Value password;
+  v8::String::Utf8Value realm;
+  v8::String::Utf8Value proxy_user;
+
+private:
+  void Set(unsigned flags, sasl_interact_t *interact);
+};
+

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,8 @@
     "targets": [
         {
             "target_name": "LDAPCnx",
-            "sources": [ "LDAP.cc", "LDAPCnx.cc", "LDAPCookie.cc" ],
+            "sources": [ "LDAP.cc", "LDAPCnx.cc", "LDAPCookie.cc", 
+              "LDAPSASL.cc", "LDAPXSASL.cc", "SASLDefaults.cc" ],
             "include_dirs" : [
  	 	"<!(node -e \"require('nan')\")",
                 "/usr/local/include"
@@ -20,9 +21,16 @@
                 "-Wall",
                 "-g"
             ],
-
+            "conditions": [
+                [ "SASL==\"n\"", { "sources!": 
+                  ["LDAPSASL.cc", "SASLDefaults.cc"] } ], 
+                [ "SASL==\"y\"", { "sources!": ["LDAPXSASL.cc"] } ]
+            ]
         }
     ],
+    "variables": {
+      "SASL": "<!(test -f /usr/include/sasl/sasl.h && echo y || echo n)"
+    },
     "conditions": [
         [
             "OS==\"mac\"",
@@ -41,5 +49,4 @@
         ]
     ]
 }
-                    
-   
+

--- a/test/run_sasl.sh
+++ b/test/run_sasl.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+if [[ -z $SLAPD ]] ; then
+  SLAPD=/usr/local/libexec/slapd
+fi
+
+if [[ -z $SLAPADD ]] ; then
+  SLAPADD=/usr/local/sbin/slapadd
+fi
+
+if [[ -z $SLAPD_CONF ]] ; then
+  SLAPD_CONF=sasl.conf
+fi
+
+MKDIR=/bin/mkdir
+RM=/bin/rm
+
+$RM -rf openldap-data
+$MKDIR openldap-data
+
+if [[ -f slapd.pid ]] ; then
+  $RM slapd.pid
+fi
+
+$SLAPADD -f $SLAPD_CONF < startup.ldif
+$SLAPADD -f $SLAPD_CONF < sasl.ldif
+$SLAPD -d999 -f $SLAPD_CONF -hldap://localhost:1234 > sasl.log 2>&1 &
+
+if [[ ! -f slapd.pid ]] ; then
+  sleep 1
+fi
+
+# Make sure SASL is enabled
+if ldapsearch -H ldap://localhost:1234 -x -b "" -s base -LLL \
+    supportedSASLMechanisms | grep -q SASL ; then
+    :
+else
+    echo slapd started but SASL not supported
+fi

--- a/test/sasl.conf
+++ b/test/sasl.conf
@@ -1,0 +1,26 @@
+include		/usr/local/etc/openldap/schema/core.schema
+include		/usr/local/etc/openldap/schema/cosine.schema
+include		/usr/local/etc/openldap/schema/inetorgperson.schema
+
+pidfile		./slapd.pid
+argsfile	./slapd.args
+
+modulepath	/usr/local/libexec/openldap
+moduleload	back_bdb
+
+idletimeout 100
+
+database	bdb
+
+sasl-auxprops slapd
+sasl-secprops none
+authz-regexp uid=(.*),cn=PLAIN,cn=auth cn=$1,dc=sample,dc=com
+authz-regexp uid=(.*),cn=authz,cn=auth cn=$1,dc=sample,dc=com
+password-hash {CLEARTEXT}
+authz-policy from
+
+suffix		"dc=sample,dc=com"
+rootdn		"cn=Manager,dc=sample,dc=com"
+rootpw		secret
+directory	./openldap-data
+index	objectClass,cn,contextCSN	eq

--- a/test/sasl.js
+++ b/test/sasl.js
@@ -1,0 +1,166 @@
+/*jshint globalstrict:true, node:true, trailing:true, mocha:true unused:true */
+
+'use strict';
+
+var LDAP = require('../');
+
+var assert = require('assert');
+
+var ldap;
+
+// Does not need to support GSSAPI
+var uri = process.env.TEST_SASL_URI || 'ldap://localhost:1234';
+
+describe('SASL PLAIN bind', function() {
+    connect(uri);
+    it('Should bind with user', function(done) {
+        ldap.saslbind({ 
+            mechanism: 'PLAIN', 
+            user: 'test_user', 
+            password: 'secret',
+            securityproperties: 'none'
+        }, function(err) {
+                assert.ifError(err);
+                done();
+        });
+    });
+    search();
+    after(cleanup);
+});
+
+describe('LDAP SASL Proxy User', function() {
+    connect(uri);
+    it('Should bind with proxy user', function(done) {
+        ldap.saslbind({ 
+            mechanism: 'PLAIN', 
+            user: 'test_user', 
+            password: 'secret',
+            proxyuser: 'u:test_admin',
+            securityproperties: 'none'
+        }, function(err) {
+            assert.ifError(err);
+            done();
+        });
+    });
+    search();
+    after(cleanup);
+});
+
+describe('SASL Error Handling', function() {
+
+    connect(uri);
+
+    it('Should fail to bind invalid password', function(done) {
+        ldap.saslbind({ 
+            mechanism: 'PLAIN', 
+            user: 'test_user', 
+            password: 'bad password',
+            securityproperties: 'none'
+        }, function(err) {
+            assert.ifError(!err);
+            done();
+        });
+    });
+
+    it('Should fail to bind invalid proxy user', function(done) {
+        ldap.saslbind({ 
+            mechanism: 'PLAIN', 
+            user: 'test_user', 
+            password: 'secret',
+            proxyuser: 'no_user',
+            securityproperties: 'none'
+       }, function(err) {
+            assert.ifError(!err);
+            done();
+       });
+    });
+
+    it('Should throw on invalid mechanism', function(done) {
+        try {
+            ldap.saslbind({ mechanism: 'INVALID' }, function(err) {
+                assert(false);
+            });
+        } 
+        catch(err) {
+        }
+        done();
+    })
+
+    it('Should throw on invalid parameter', function(done) {
+        try {
+            ldap.saslbind({realm: 0}, function(err) {
+                assert(false);
+            });
+        } 
+        catch(err) {
+        }
+        done();
+    });
+
+    after(cleanup);
+});
+
+// Needs to be a server that supports SASL authentication with default 
+// credentials (e.g. GSSAPI)
+var gssapi_uri = process.env.TEST_SASL_GSSAPI_URI;
+if(gssapi_uri) {
+    describe('LDAP SASL GSSAPI', function() {
+        connect(gssapi_uri);
+        it('Should bind with default credentials', function(done) {
+            this.timeout(10000);
+            ldap.saslbind(function(err) {
+                assert.ifError(err);
+                done();
+            });
+        });
+        search();
+        after(cleanup);
+    });
+}
+
+function connect(uri) {
+    it('Should connect', function(done) {
+        ldap = new LDAP({ uri: uri }, function(err) {
+            assert.ifError(err);
+            done();
+        });
+    });
+}
+
+function search() {
+	var dc;
+    it('Should be able to get root info', function(done) {
+        ldap.search({
+            base: '',
+            scope:  LDAP.BASE,
+			attrs: 'namingContexts'
+        }, function(err, res) {
+            assert.ifError(err);
+            assert(res.length);
+			var ctx = res[0].namingContexts.filter(function(c) {
+				return c.indexOf('{') < 0; // Avoid AD config context
+			});
+			dc = ctx[0];
+            done();
+        });
+    });
+    it('Should be able to search', function(done) {
+        ldap.search({
+            filter: '(objectClass=*)',
+            base: dc,
+            scope:  LDAP.ONELEVEL,
+			attrs: 'cn'
+        }, function(err, res) {
+            assert.ifError(err);
+            assert(res.length);
+            done();
+        });
+    });
+}
+
+function cleanup() {
+    if(ldap) {
+        ldap.close();
+        ldap = undefined;
+    }
+}

--- a/test/sasl.ldif
+++ b/test/sasl.ldif
@@ -1,0 +1,15 @@
+dn: cn=test_user,dc=sample,dc=com
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: test_user
+sn: test_user
+userPassword: secret
+
+dn: cn=test_admin,dc=sample,dc=com
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: test_admin
+sn: test_admin
+authzFrom: u:test_user


### PR DESCRIPTION
Only tested with PLAIN and GSSAPI support on Linux.
Requires Cyrus SASL installed at /usr/include/sasl/sasl.h.

GSSAPI support tested with AD and LDS.
PLAIN tested with OpenLDAP.