### PR TITLE
SASL GSSAPI bind was not being completed.

### DIFF
--- a/LDAPSASL.cc
+++ b/LDAPSASL.cc
@@ -53,7 +53,7 @@ int LDAPCnx::SASLBindNext(LDAPMessage** message) {
 
     ldap_msgfree(*message);
 
-    if(ldap_result(ld, msgid, LDAP_MSG_ALL, NULL, message) != LDAP_SUCCESS) { 
+    if(ldap_result(ld, msgid, LDAP_MSG_ALL, NULL, message) == -1) { 
       ldap_get_option(ld, LDAP_OPT_RESULT_CODE, &res);
       break;
     }


### PR DESCRIPTION
Apologies but I realized that I broke the GSSAPI login when cleaning up the code for the patch.  I do not have a reliable general way to test GSSAPI connections.  The test I have does not catch incomplete binds.  I will need to give some thought to a better test for this.   I have tried the SASL patch now in a real application with GSSAPI and it does appear to be working correctly with this patch.