### PR TITLE
Removing Dependence on lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,21 @@ var binding = require('bindings')('LDAPCnx');
 var LDAPError = require('./LDAPError');
 var assert = require('assert');
 var util = require('util');
-var _ = require('lodash');
 
 function arg(val, def) {
     if (val !== undefined) {
         return val;
     }
     return def;
+}
+
+function extendobj(target, other) {
+  var keys = Object.keys(other);
+  for (var index = 0; index < keys.length; ++index) {
+    var key = keys[index];
+    target[key] = other[key];
+  }
+  return target;
 }
 
 var escapes = {
@@ -65,7 +73,7 @@ function LDAP(opt, fn) {
     this.queue = {};
     this.stats = new Stats();
 
-    this.options = _.assign({
+    this.options = extendobj({
         base:         'dc=com',
         filter:       '(objectClass=*)',
         scope:        2,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "lodash": "^3.10.1",
     "nan": "^2.12.1",
     "node-gyp": ""
   },


### PR DESCRIPTION
The following change removes the project dependency lodash. Previously, just the `assign()` function from lodash was used in a single place to apply the user's supplied options to the `options` object used internally by the `LDAP` class. This has been replaced by a new function `extendobj()` which is not equivalent to `assign()`, but accomplishes the same goal.

Closes #114