### PR TITLE
Unset handler on disconnect

### DIFF
--- a/LDAPCnx.cc
+++ b/LDAPCnx.cc
@@ -269,6 +269,7 @@ void LDAPCnx::OnDisconnect(LDAP *ld, Sockbuf *sb,
   LDAPCnx * lc = (LDAPCnx *)ctx->lc_arg;
   if (lc->handle) {
     uv_poll_stop(lc->handle);
+    lc->handle = NULL;
   }
   lc->disconnect_callback->Call(0, NULL);
 }


### PR DESCRIPTION
This fixes a bug where uv_poll_stop was called twice on a handle.

Explanation of the bug:
In the OnDisconnect callback, it calls uv_poll_stop to stop watching
the handle. Later, in OnConnect, it sees that the handle is non-NULL
and calls uv_poll_stop again.

